### PR TITLE
Update open mode from U to r

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from os import path
 
-long_desc = open(path.join(path.dirname(__file__), "README.md"), "U").read()
+long_desc = open(path.join(path.dirname(__file__), "README.md"), "r").read()
 
 setup(name="fish", version="1.1",
       url="http://sendapatch.se/",


### PR DESCRIPTION
The U mode flag was deprecated completely in Python 3.11. It was being used in the setup.py, which prevents fish from being installed.